### PR TITLE
Fix string decoder example in 1.5

### DIFF
--- a/1.5/StringDecoder.js
+++ b/1.5/StringDecoder.js
@@ -2,11 +2,11 @@ const { StringDecoder } = require('string_decoder');
 const decoder = new StringDecoder('utf8');
 
 process.stdin.on('readable', () => {
-  const chunk = process.stdin.read();
-  if (chunk != null) {
-    const buffer = Buffer.from([chunk]);
-    console.log('With .toString():', buffer.toString());
-    console.log('With StringDecoder:', decoder.write(buffer));
+  let chunk;
+  while((chunk = process.stdin.read()) !== null) {
+    const buff = Buffer.from([chunk])
+    console.log('With .toString():', buff.toString());
+    console.log('With StringDecoder:', decoder.write(buff));
   }
 });
 


### PR DESCRIPTION
Hi, I recently started your course on advanced nodejs on plural sight and noticed that String Decoder example for Chapter 1, lecture 5 is broken after process stdin changes.

Tested on LTS Node 12
